### PR TITLE
Fix `immintrin.h` not found in RISC-V

### DIFF
--- a/modules/juce_dsp/juce_dsp.h
+++ b/modules/juce_dsp/juce_dsp.h
@@ -58,7 +58,7 @@
 #include <juce_audio_basics/juce_audio_basics.h>
 #include <juce_audio_formats/juce_audio_formats.h>
 
-#if defined(_M_X64) || defined(__amd64__) || defined(__SSE2__) || (defined(_M_IX86_FP) && _M_IX86_FP == 2) || defined(__riscv) || defined(__EMSCRIPTEN__)
+#if defined(_M_X64) || defined(__amd64__) || defined(__SSE2__) || (defined(_M_IX86_FP) && _M_IX86_FP == 2) || defined(__EMSCRIPTEN__)
 
  #if defined(_M_X64) || defined(__amd64__)
   #ifndef __SSE2__
@@ -81,6 +81,20 @@
  #endif
 
  #include <arm_neon.h>
+
+#elif defined(__riscv)
+
+ #ifndef JUCE_USE_SIMD
+  #define JUCE_USE_SIMD 1
+ #endif
+
+ #if JUCE_USE_SIMD
+  #ifndef SIMDE_ENABLE_NATIVE_ALIASES
+   #define SIMDE_ENABLE_NATIVE_ALIASES
+  #endif
+ #endif
+
+ #include "simde/x86/sse2.h"
 
 #else
 


### PR DESCRIPTION
I am trying to build `surge` on RISC-V, but I have the same problem as SpriteOvO in https://github.com/surge-synthesizer/JUCE/pull/3 . So I adopted his/her solution, and I think this should be merged into this repo.